### PR TITLE
fix:  troubleshoot transformErrors function

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -227,13 +227,14 @@ class App extends Component {
      * }
      */
     transformErrors = (errors) => errors.map((err) => {
-      const {schema, schemaPath} = err;
-      const pathParts = schemaPath.split('.');
-      const tail = pathParts.pop();
-      const path = pathParts.concat('messages', tail).join('.');
-      const maybeCustomMessage = get(schema, path);
-      if (maybeCustomMessage) {
-        err.message = maybeCustomMessage;
+      const {property, name} = err;
+      const {schema} = this.state;
+      const pathParts = property.split('.');
+      const prefix = pathParts.join('.properties.').substring(1); // remove leading period (.)
+      const messageLocation = prefix + '.messages.' + name;
+      const customMessage = get(schema, messageLocation);
+      if (customMessage) {
+        err.message = customMessage;
       }
       return err;
     });


### PR DESCRIPTION
For me (on Chrome), the `err` object contains the following:

```
message: "should match pattern "^\d{3}-\d{3}-\d{4}$"",
name: "pattern",
params: {pattern: "^\d{3}-\d{3}-\d{4}$"},
property: ".contact_information.primary_cell_number",
stack: ".contact_information.primary_cell_number should match pattern "^\d{3}-\d{3}-\d{4}$"",
__proto__: Object
```